### PR TITLE
Run for ABAP file format type `CHKC`

### DIFF
--- a/src/zajson_perf_test.prog.abap
+++ b/src/zajson_perf_test.prog.abap
@@ -501,27 +501,27 @@ class lcl_app implementation.
 
       lo_app->run( 'parse_plain_obj' ).
       lo_app->run( 'parse_aff_chkc' ).
-*      lo_app->run( 'parse_deep_obj' ).
-*      lo_app->run( 'parse_array' ).
-*      lo_app->run(
-*        iv_method = 'parse_long_array'
-*        iv_times  = 5 ).
-*      lo_app->run(
-*        iv_method = 'parse_complex'
-*        iv_times  = 5 ).
-*
+      lo_app->run( 'parse_deep_obj' ).
+      lo_app->run( 'parse_array' ).
+      lo_app->run(
+        iv_method = 'parse_long_array'
+        iv_times  = 5 ).
+      lo_app->run(
+        iv_method = 'parse_complex'
+        iv_times  = 5 ).
+
       lo_app->prepare_parsed( ).
 
       lo_app->run( 'to_abap_plain_obj' ).
       lo_app->run( 'to_abap_aff_chkc' ).
-*      lo_app->run( 'to_abap_deep_obj' ).
-*      lo_app->run( 'to_abap_array' ).
-*      lo_app->run(
-*        iv_method = 'to_abap_long_array'
-*        iv_times  = 5 ).
-*      lo_app->run(
-*        iv_method = 'to_abap_complex'
-*        iv_times  = 5 ).
+      lo_app->run( 'to_abap_deep_obj' ).
+      lo_app->run( 'to_abap_array' ).
+      lo_app->run(
+        iv_method = 'to_abap_long_array'
+        iv_times  = 5 ).
+      lo_app->run(
+        iv_method = 'to_abap_complex'
+        iv_times  = 5 ).
 
     catch cx_root into lx.
       lv_tmp = lx->get_text( ).

--- a/src/zajson_perf_test.prog.abap
+++ b/src/zajson_perf_test.prog.abap
@@ -111,12 +111,14 @@ class lcl_app definition final inheriting from lcl_runner_base.
   public section.
 
     methods parse_plain_obj raising cx_static_check.
+    methods parse_aff_chkc raising cx_static_check.
     methods parse_deep_obj raising cx_static_check.
     methods parse_array raising cx_static_check.
     methods parse_long_array raising cx_static_check.
     methods parse_complex raising cx_static_check.
 
     methods to_abap_plain_obj raising cx_static_check.
+    methods to_abap_aff_chkc raising cx_static_check.
     methods to_abap_deep_obj raising cx_static_check.
     methods to_abap_array raising cx_static_check.
     methods to_abap_long_array raising cx_static_check.
@@ -149,6 +151,7 @@ class lcl_app definition final inheriting from lcl_runner_base.
         iv_lines type i.
 
     data mv_json_plain_obj type string.
+    data mv_json_aff_chkc type string.
     data mv_json_deep type string.
     data mv_json_array type string.
     data mv_json_long_array type string.
@@ -158,6 +161,7 @@ class lcl_app definition final inheriting from lcl_runner_base.
     data mr_long_array type ref to data.
 
     data mo_plain_obj type ref to zif_ajson.
+    data mo_aff_chkc type ref to zif_ajson.
     data mo_deep type ref to zif_ajson.
     data mo_array type ref to zif_ajson.
     data mo_long_array type ref to zif_ajson.
@@ -209,6 +213,16 @@ class lcl_app implementation.
       '  "date": "2020-03-15",' &&
       '  "str1": "hello",' &&
       '  "str2": "world"' &&
+      '}'.
+
+    mv_json_aff_chkc =
+      '{' &&
+      '  "formatVersion": "1",' &&
+      '  "header": {' &&
+      '    "description": "Example CHKC for ABAP file formats",' &&
+      '    "originalLanguage": "en"' &&
+      '  },' &&
+      '  "parentCategory": "SYCM_S4H_READINESS"' &&
       '}'.
 
     mv_json_deep =
@@ -373,6 +387,7 @@ class lcl_app implementation.
   method prepare_parsed.
 
     mo_plain_obj  = zcl_ajson=>parse( mv_json_plain_obj ).
+    mo_aff_chkc   = zcl_ajson=>parse( mv_json_aff_chkc ).
     mo_deep       = zcl_ajson=>parse( mv_json_deep ).
     mo_array      = zcl_ajson=>parse( mv_json_array ).
     mo_complex    = zcl_ajson=>parse( mv_json_complex ).
@@ -386,6 +401,14 @@ class lcl_app implementation.
     lo_json = zcl_ajson=>parse( mv_json_plain_obj ).
 
   endmethod.
+
+  method parse_aff_chkc.
+
+    data lo_json type ref to zif_ajson.
+    lo_json = zcl_ajson=>parse( mv_json_aff_chkc ).
+
+  endmethod.
+
 
   method parse_deep_obj.
 
@@ -419,6 +442,13 @@ class lcl_app implementation.
 
     data ls_target type ty_plain.
     mo_plain_obj->to_abap( importing ev_container = ls_target ).
+
+  endmethod.
+
+  method to_abap_aff_chkc.
+
+    data ls_target type if_aff_chkc_v1=>ty_main.
+    mo_aff_chkc->to_abap( importing ev_container = ls_target ).
 
   endmethod.
 
@@ -470,26 +500,28 @@ class lcl_app implementation.
       lo_app->prepare( ).
 
       lo_app->run( 'parse_plain_obj' ).
-      lo_app->run( 'parse_deep_obj' ).
-      lo_app->run( 'parse_array' ).
-      lo_app->run(
-        iv_method = 'parse_long_array'
-        iv_times  = 5 ).
-      lo_app->run(
-        iv_method = 'parse_complex'
-        iv_times  = 5 ).
-
+      lo_app->run( 'parse_aff_chkc' ).
+*      lo_app->run( 'parse_deep_obj' ).
+*      lo_app->run( 'parse_array' ).
+*      lo_app->run(
+*        iv_method = 'parse_long_array'
+*        iv_times  = 5 ).
+*      lo_app->run(
+*        iv_method = 'parse_complex'
+*        iv_times  = 5 ).
+*
       lo_app->prepare_parsed( ).
 
       lo_app->run( 'to_abap_plain_obj' ).
-      lo_app->run( 'to_abap_deep_obj' ).
-      lo_app->run( 'to_abap_array' ).
-      lo_app->run(
-        iv_method = 'to_abap_long_array'
-        iv_times  = 5 ).
-      lo_app->run(
-        iv_method = 'to_abap_complex'
-        iv_times  = 5 ).
+      lo_app->run( 'to_abap_aff_chkc' ).
+*      lo_app->run( 'to_abap_deep_obj' ).
+*      lo_app->run( 'to_abap_array' ).
+*      lo_app->run(
+*        iv_method = 'to_abap_long_array'
+*        iv_times  = 5 ).
+*      lo_app->run(
+*        iv_method = 'to_abap_complex'
+*        iv_times  = 5 ).
 
     catch cx_root into lx.
       lv_tmp = lx->get_text( ).

--- a/src/zajson_perf_test.prog.abap
+++ b/src/zajson_perf_test.prog.abap
@@ -217,12 +217,12 @@ class lcl_app implementation.
 
     mv_json_aff_chkc =
       '{' &&
-      '  "formatVersion": "1",' &&
+      '  "formatversion": "1",' &&
       '  "header": {' &&
       '    "description": "Example CHKC for ABAP file formats",' &&
-      '    "originalLanguage": "en"' &&
+      '    "originallanguage": "en"' &&
       '  },' &&
-      '  "parentCategory": "SYCM_S4H_READINESS"' &&
+      '  "parentcategory": "SYCM_S4H_READINESS"' &&
       '}'.
 
     mv_json_deep =

--- a/src/zajson_perf_test.prog.abap
+++ b/src/zajson_perf_test.prog.abap
@@ -447,7 +447,7 @@ class lcl_app implementation.
 
   method to_abap_aff_chkc.
 
-    data ls_target type if_aff_chkc_v1=>ty_main.
+    data ls_target type zif_aff_chkc_v1=>ty_main.
     mo_aff_chkc->to_abap( importing ev_container = ls_target ).
 
   endmethod.

--- a/src/zif_aff_chkc_v1.intf.abap
+++ b/src/zif_aff_chkc_v1.intf.abap
@@ -6,14 +6,14 @@ INTERFACE zif_aff_chkc_v1
     "! ATC check category properties
     BEGIN OF ty_main,
       "! $required
-      format_version  TYPE if_aff_types_v1=>ty_format_version,
+      formatversion  TYPE zif_aff_types_v1=>ty_format_version,
       "! <p class="shorttext">Header</p>
       "! Header
       "! $required
-      header          TYPE if_aff_types_v1=>ty_header_60,
+      header          TYPE zif_aff_types_v1=>ty_header_60,
       "! <p class="shorttext">Parent Category</p>
       "! Name of the parent category
-      parent_category TYPE if_aff_types_v1=>ty_object_name_30,
+      parentcategory TYPE zif_aff_types_v1=>ty_object_name_30,
     END OF ty_main.
 
 ENDINTERFACE.

--- a/src/zif_aff_chkc_v1.intf.abap
+++ b/src/zif_aff_chkc_v1.intf.abap
@@ -1,0 +1,19 @@
+INTERFACE zif_aff_chkc_v1
+  PUBLIC.
+
+  TYPES:
+    "! <p class="shorttext">ATC Check Category</p>
+    "! ATC check category properties
+    BEGIN OF ty_main,
+      "! $required
+      format_version  TYPE if_aff_types_v1=>ty_format_version,
+      "! <p class="shorttext">Header</p>
+      "! Header
+      "! $required
+      header          TYPE if_aff_types_v1=>ty_header_60,
+      "! <p class="shorttext">Parent Category</p>
+      "! Name of the parent category
+      parent_category TYPE if_aff_types_v1=>ty_object_name_30,
+    END OF ty_main.
+
+ENDINTERFACE.

--- a/src/zif_aff_chkc_v1.intf.xml
+++ b/src/zif_aff_chkc_v1.intf.xml
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_INTF" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOINTERF>
+    <CLSNAME>ZIF_AFF_CHKC_V1</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>CHKC AFF Types</DESCRIPT>
+    <EXPOSURE>2</EXPOSURE>
+    <STATE>1</STATE>
+    <UNICODE>X</UNICODE>
+   </VSEOINTERF>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/zif_aff_types_v1.intf.abap
+++ b/src/zif_aff_types_v1.intf.abap
@@ -110,7 +110,7 @@ INTERFACE zif_aff_types_v1 PUBLIC.
       "! $required
       description           TYPE ty_description_60,
       "! $required
-      original_language     TYPE ty_original_language,
+      originallanguage     TYPE ty_original_language,
       abap_language_version TYPE ty_abap_language_version,
     END OF ty_header_60.
 

--- a/src/zif_aff_types_v1.intf.abap
+++ b/src/zif_aff_types_v1.intf.abap
@@ -1,0 +1,194 @@
+"! <p class="shorttext synchronized" lang="en">General types reusable in AFF</p>
+"! Types which can be reused in all AFF object types
+INTERFACE zif_aff_types_v1 PUBLIC.
+
+  "! <p class="shorttext">ABAP File Format Version</p>
+  "! The ABAP file format version
+  TYPES ty_format_version TYPE string.
+
+  "! <p class="shorttext">ABAP Language Version</p>
+  "! ABAP language version
+  "! $values {@link if_aff_types_v1.data:co_abap_language_version}
+  "! $default {@link if_aff_types_v1.data:co_abap_language_version.standard}
+  TYPES ty_abap_language_version TYPE c LENGTH 1.
+
+  "! <p class="shorttext">ABAP Language Version</p>
+  "! ABAP language version
+  "! $values {@link if_aff_types_v1.data:co_abap_language_version_cloud}
+  "! $default {@link if_aff_types_v1.data:co_abap_language_version_cloud.standard}
+  TYPES ty_abap_language_version_cloud TYPE c LENGTH 1.
+
+  "! <p class="shorttext">ABAP Language Version</p>
+  "! ABAP language version
+  "! $values {@link if_aff_types_v1.data:co_abap_language_version_src}
+  "! $default {@link if_aff_types_v1.data:co_abap_language_version_src.standard}
+  TYPES ty_abap_language_version_src TYPE c LENGTH 1.
+
+  CONSTANTS:
+    "! <p class="shorttext">ABAP Language Version (Source Code Objects)</p>
+    "! ABAP language version for source code objects like CLAS, INTF, FUGR or PROG.
+    BEGIN OF co_abap_language_version_src,
+      "! <p class="shorttext">Standard</p>
+      "! Standard
+      standard          TYPE ty_abap_language_version_src VALUE 'X',
+      "! <p class="shorttext">ABAP for Key Users</p>
+      "! ABAP for key user extensibility
+      key_user          TYPE ty_abap_language_version_src VALUE '2',
+      "! <p class="shorttext">ABAP Cloud Development</p>
+      "! ABAP cloud development
+      cloud_development TYPE ty_abap_language_version_src VALUE '5',
+    END OF co_abap_language_version_src.
+
+  CONSTANTS:
+    "! <p class="shorttext">ABAP Language Version (Non-Source Code Objects)</p>
+    "! ABAP language version for non-source code objects
+    BEGIN OF co_abap_language_version,
+      "! <p class="shorttext">Standard</p>
+      "! Standard
+      standard          TYPE ty_abap_language_version VALUE space,
+      "! <p class="shorttext">ABAP for Key Users</p>
+      "! ABAP for key user extensibility
+      key_user          TYPE ty_abap_language_version VALUE '2',
+      "! <p class="shorttext">ABAP Cloud Development</p>
+      "! ABAP cloud development
+      cloud_development TYPE ty_abap_language_version VALUE '5',
+    END OF co_abap_language_version.
+
+  CONSTANTS:
+    "! <p class="shorttext">ABAP Language Version</p>
+    "! ABAP language version for objects which only exist for standard and cloud development (no key user extensibility)
+    BEGIN OF co_abap_language_version_cloud,
+      "! <p class="shorttext">Standard</p>
+      "! Standard
+      standard          TYPE ty_abap_language_version_cloud VALUE space,
+      "! <p class="shorttext">ABAP Cloud Development</p>
+      "! ABAP cloud development
+      cloud_development TYPE ty_abap_language_version_cloud VALUE '5',
+    END OF co_abap_language_version_cloud.
+
+  "! <p class="shorttext">Description</p>
+  "! Description of the ABAP object
+  TYPES ty_description_60 TYPE c LENGTH 60.
+  "! <p class="shorttext">Description</p>
+  "! Description of the ABAP object
+  TYPES ty_description_100 TYPE c LENGTH 100.
+
+  "! <p class="shorttext">Object Name</p>
+  "! Object name with max. length 30
+  TYPES ty_object_name_30 TYPE c LENGTH 30.
+
+  "! <p class="shorttext">Original Language</p>
+  "! Original language of the ABAP object
+  TYPES ty_original_language TYPE sy-langu.
+
+  TYPES:
+    "! <p class="shorttext">Header for Source Code Objects</p>
+    "! The header for an ABAP main object (with source code) with a description of 60 characters
+    BEGIN OF ty_header_60_src,
+      "! $required
+      description           TYPE ty_description_60,
+      "! $required
+      original_language     TYPE ty_original_language,
+      abap_language_version TYPE ty_abap_language_version_src,
+    END OF ty_header_60_src.
+
+  TYPES:
+    "! <p class="shorttext">Header for Non-Source Code Objects (no key user)</p>
+    "! The header for an ABAP main object (without source code) with a description of 60 characters (no key user)
+    BEGIN OF ty_header_60_cloud,
+      "! $required
+      description           TYPE ty_description_60,
+      "! $required
+      original_language     TYPE ty_original_language,
+      abap_language_version TYPE ty_abap_language_version_cloud,
+    END OF ty_header_60_cloud.
+
+  TYPES:
+    "! <p class="shorttext">Header for Non-Source Code Objects</p>
+    "! The header for an ABAP main object (without source code) with a description of 60 characters
+    BEGIN OF ty_header_60,
+      "! $required
+      description           TYPE ty_description_60,
+      "! $required
+      original_language     TYPE ty_original_language,
+      abap_language_version TYPE ty_abap_language_version,
+    END OF ty_header_60.
+
+  TYPES:
+    "! <p class="shorttext">Header for Non-Source Code Objects</p>
+    "! The header for an ABAP main object (without source code) with a description of 100 characters
+    BEGIN OF ty_header_100,
+      "! $required
+      description           TYPE ty_description_100,
+      "! $required
+      original_language     TYPE ty_original_language,
+      abap_language_version TYPE ty_abap_language_version,
+    END OF ty_header_100.
+
+  TYPES:
+    "! <p class="shorttext">Header for Subobjects</p>
+    "! The header for an ABAP  subobject with a description of 60 characters
+    BEGIN OF ty_header_only_description,
+      "! $required
+      description TYPE ty_description_60,
+    END OF ty_header_only_description.
+
+  "! <p class="shorttext">Option</p>
+  "! Option
+  "! $values {@link if_aff_types_v1.data:co_option}
+  TYPES ty_option TYPE c LENGTH 2.
+
+  CONSTANTS:
+    "! <p class="shorttext">Option</p>
+    "! Option
+    BEGIN OF co_option,
+      "! <p class="shorttext">Equals</p>
+      "! Equals
+      equals               TYPE ty_option VALUE 'EQ',
+      "! <p class="shorttext">Between</p>
+      "! Between
+      between              TYPE ty_option VALUE 'BT',
+      "! <p class="shorttext">Greater Than</p>
+      "! Greater than
+      greater_than         TYPE ty_option VALUE 'GT',
+      "! <p class="shorttext">Contains Pattern</p>
+      "! Contains pattern
+      contains_pattern     TYPE ty_option VALUE 'CP',
+      "! <p class="shorttext">Not Equal</p>
+      "! Not equal
+      not_equal            TYPE ty_option VALUE 'NE',
+      "! <p class="shorttext">Not Between</p>
+      "! Not between
+      not_between          TYPE ty_option VALUE 'NB',
+      "! <p class="shorttext">Not Contains Pattern</p>
+      "! Not contains pattern
+      not_contains_pattern TYPE ty_option VALUE 'NP',
+      "! <p class="shorttext">Greater Equal</p>
+      "! Greater equal
+      greater_equal        TYPE ty_option VALUE 'GE',
+      "! <p class="shorttext">Less Than</p>
+      "! Less than
+      less_than            TYPE ty_option VALUE 'LT',
+      "! <p class="shorttext">Less Equal</p>
+      "! Less equal
+      less_equal           TYPE ty_option VALUE 'LE',
+    END OF co_option.
+
+  "! <p class="shorttext">Sign</p>
+  "! Sign
+  "! $values {@link if_aff_types_v1.data:co_sign}
+  TYPES ty_sign TYPE c LENGTH 1.
+
+  CONSTANTS:
+    "! <p class="shorttext">Sign</p>
+    "! Sign
+    BEGIN OF co_sign,
+      "! <p class="shorttext">Exclude</p>
+      "! Exclude
+      exclude TYPE ty_sign VALUE 'E',
+      "! <p class="shorttext">Include</p>
+      "! Include
+      include TYPE ty_sign VALUE 'I',
+    END OF co_sign.
+
+ENDINTERFACE.

--- a/src/zif_aff_types_v1.intf.xml
+++ b/src/zif_aff_types_v1.intf.xml
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_INTF" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOINTERF>
+    <CLSNAME>ZIF_AFF_TYPES_V1</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>General types reusable in AFF</DESCRIPT>
+    <EXPOSURE>2</EXPOSURE>
+    <STATE>1</STATE>
+    <UNICODE>X</UNICODE>
+   </VSEOINTERF>
+  </asx:values>
+ </asx:abap>
+</abapGit>


### PR DESCRIPTION
Let's do performance test for an ABAP file format type.

Introduced two methods for the CHKC object type.
- [x] parse_aff_chkc 
- [x] to_abap_aff_chkc